### PR TITLE
Enhance artist list response with cover and listing images, to match front end expansion

### DIFF
--- a/tag-web-api/tag-web-api/Controllers/ArtistController.cs
+++ b/tag-web-api/tag-web-api/Controllers/ArtistController.cs
@@ -36,10 +36,24 @@ public class ArtistController : ControllerBase
     [HttpGet(Name = "GetArtists")]
     public async Task<ActionResult<IEnumerable<Artist>>> Get()
     {
-        return await _context.Set<Artist>()
+        var artists = await _context.Set<Artist>()
             .Include(a => a.ProfilePic)
+            .Include(a => a.CoverPic)
+            .Include(a => a.Listings)
+                .ThenInclude(l => l.ProfilePic)
             .ToListAsync()
             .ConfigureAwait(false);
+
+        // Limit each artist's listings to top 3 for gallery preview
+        foreach (var artist in artists)
+        {
+            if (artist.Listings != null && artist.Listings.Count > 3)
+            {
+                artist.Listings = artist.Listings.Take(3).ToList();
+            }
+        }
+
+        return artists;
     }
 
     [HttpGet("byID/{id}")]

--- a/tag-web-api/tag-web-api/Models/Artist.cs
+++ b/tag-web-api/tag-web-api/Models/Artist.cs
@@ -50,6 +50,8 @@ public class Artist
 
     public virtual ICollection<LinkerArtistToCategory>? ArtistCategoryLinks { get; set; } = new List<LinkerArtistToCategory>();
 
+    public virtual ICollection<Listing>? Listings { get; set; } = new List<Listing>();
+
     public void SetPath(string path)
     {
         Path = path.ToLower();

--- a/tag-web-api/tag-web-api/Models/Listing.cs
+++ b/tag-web-api/tag-web-api/Models/Listing.cs
@@ -4,6 +4,7 @@
 
 using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
+using System.Text.Json.Serialization;
 
 namespace TAGWEBAPI.Models;
 
@@ -62,6 +63,7 @@ public class Listing
     [ForeignKey("Artist")]
     public int ArtistID { get; set; }
 
+    [JsonIgnore]
     public Artist Artist { get; set; }
 
     [ForeignKey("Picture")]


### PR DESCRIPTION
#25 feat(api): include artist cover and listing preview images in artist list response

include CoverPic in GET /api/artist list payload
include up to 3 listings per artist with listing ProfilePic add Artist.Listings navigation property for eager loading add JsonIgnore on Listing.Artist to prevent circular serialization